### PR TITLE
docs(skill): treat module-level 404 as module-not-installed

### DIFF
--- a/skills/dce/SKILL.md
+++ b/skills/dce/SKILL.md
@@ -32,6 +32,16 @@ Use this skill when a user asks you to operate `dce`, inspect its API commands, 
 - Read `references/modules/insight.md` for the `insight` module command index.
 - Read `references/modules/operations-management.md` for the `operations-management` module command index.
 
+## Module availability
+
+The catalog (`dce commands` / `dce search`) lists every module `dce` was built with, **regardless of which modules are actually installed on the target host**. A command appearing in the catalog does not guarantee its module is deployed.
+
+A `404` / route-not-found at the **module path level** (the API route itself does not exist, not a specific object) is ambiguous: the module may not be installed, or the path/version may be wrong. On such a `404`, **actively confirm before concluding** by running `dce global-management about list-g-product-versions -o json` (global-management is the always-present base module, so this is always available). Then:
+
+- **Module not in the list** → it is not installed on this host. Do not retry, do not try sibling commands in the same module, and do not tell the user the capability exists — state plainly that the module is not installed.
+- **Module in the list** → it is installed, so the `404` is not a missing module. Re-check the exact path and params with `dce commands show <path...> --json` (likely a wrong path/version or a resource-level not-found); do not report the module as missing.
+- **Resource-level `404`** (a specific ID/name on an otherwise-working module) means **that object** doesn't exist, not that the module is missing — handle that normally.
+
 ## Rules
 
 - Do not guess flags or request body shape from command names.

--- a/skills/dce/references/catalog.md
+++ b/skills/dce/references/catalog.md
@@ -10,6 +10,8 @@ Run `dce search "<intent>" --json` to find candidate commands. Use `--limit` to 
 
 Run `dce commands --json` to inspect the generated command catalog. Use `--include-hidden` only when hidden commands are relevant.
 
+The catalog is static: it reflects every module `dce` was built with, **not** what is installed on the target host. Presence in the catalog does not mean the module is deployed. A module-level `404` (the API route does not exist) is ambiguous — module not installed, or wrong path/version. On such a `404`, actively confirm by running `dce global-management about list-g-product-versions -o json`: if the module is absent from the list it is not installed (don't retry sibling commands; report it as not installed); if it is present, the module exists and the `404` is a wrong path/version or resource-level not-found, so re-check with `dce commands show <path...> --json`. A resource-level `404` (specific ID/name) on a working module is a normal "object not found", not a missing module.
+
 Key fields:
 
 - `path`: command path to pass to `commands show` or execute after the CLI name.


### PR DESCRIPTION
The dce catalog is static and lists every module the binary was built with, regardless of what is installed on the target host. When a host has fewer modules deployed, an agent can discover and call commands for absent modules and hit raw 404s, then retry or assume the capability exists.

Add guidance to SKILL.md and references/catalog.md: treat a module-path 404 as "module not installed in this environment" (stop, don't retry sibling commands, don't claim the feature exists), while distinguishing it from a resource-level 404 (a specific object missing on a working module). Point at `about list-g-product-versions` as the authoritative check of installed gproducts.