### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!-- Thanks for contributing! Fill in the sections below and delete this comment. -->
+
+## Related issue
+
+<!-- Link the issue this PR relates to. Use `Refs #<n>` to link without closing it
+     (avoid `Closes`/`Fixes`/`Resolves`, which auto-close the issue on merge). -->
+Refs #
+
+## Why
+
+<!-- The problem or need this change addresses. -->
+
+## What
+
+<!-- The change itself. For generated output (internal/generated/, skills/dce/),
+     note that it comes from `make bootstrap` and is intentionally committed. -->
+
+## Verification
+
+<!-- How you confirmed it works: tests, `make bootstrap` (deterministic / no diff),
+     `go build ./...`, `make build`, manual checks. -->
+
+## Checklist
+
+- [ ] Tests or focused verification cover the changed surface.
+- [ ] User-facing behavior changes are documented.
+
+<!-- Note: generated files staying in sync is enforced by CI (`make bootstrap`
+     must produce no diff), so it is not a manual checklist item. -->


### PR DESCRIPTION
## Related issue

Refs # <!-- none; repo-maintenance chore -->

## Why

The repo has no PR template, so PRs arrive in inconsistent shapes and reviewers repeatedly have to ask for the same context (what changed, why, how it was checked).

## What

Add `.github/pull_request_template.md` with **Related issue / Why / What / Verification** sections and a two-item checklist.

## Verification

Template-only change — a single Markdown file, no code paths touched (`git diff --stat` shows only `.github/pull_request_template.md`). This PR's own description is written against the new template as a first use.

## Checklist

- [x] Tests or focused verification cover the changed surface. <!-- N/A: docs/template only -->
- [x] User-facing behavior changes are documented. <!-- the template is self-documenting -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)