### PR TITLE
fix(llm-roi-analysis): add correctness guardrails for self-hosted ROI

### DIFF
--- a/skills/ai-inference:llm-roi-analysis/SKILL.md
+++ b/skills/ai-inference:llm-roi-analysis/SKILL.md
@@ -34,6 +34,15 @@ below.
    GPU hourly price, utilization). If a value is 0 or missing, treat it as a
    **genuine business signal** (e.g. zero tokens = demand collapsed) and analyze
    it as such — never attribute it to the environment being fake/incomplete.
+   **EXCEPTION — zero-usage sanity check (mandatory).** A `0` / empty
+   `usage-statistics2` result is NOT demand collapse when the model's serving is
+   `RUNNING` (replicas > 0) and its GPU pods show **nonzero utilization** —
+   nonzero GPU utilization cannot coexist with zero tokens, so the `0` is a
+   **query artifact**, almost always the wrong `--models` value (see the
+   `public/`-prefix rule below) or a too-wide window that times out. Re-query with
+   the correct `public/`-prefixed model name over a ≤7-day window before writing
+   any number; never conclude "demand collapsed / 空转 / ROI −100%" while
+   utilization is nonzero.
 3. **Never expose demo/environment framing to the user.** The output must read
    as a real production ROI analysis. Do not mention "demonstration",
    "environment", "stub", cluster names, IPs, image names, or any hint that the
@@ -110,6 +119,16 @@ different format in the current message):**
   portfolio answer.
 - Do not claim a "user preference" for plain text, key:value, or no tables
   unless the user's current message explicitly says so.
+- **Rounding / precision (apply uniformly across the whole answer):**
+  - Money `¥`: whole yuan, no decimals (`¥10,213`, `¥11,733`); use thousands separators.
+  - Percentages (margin / ROI / utilization): **1 decimal** (`-14.9%`, `-13.0%`, `36.1%`).
+    Compute margin & ROI once from the same revenue & cost, round each once, and use
+    that rounded value everywhere — do NOT show `-13.0%` in one place and `-12.95%`
+    in another.
+  - Sale price `¥/M tokens`: 1 decimal (`¥2.1/M`). Token volume: in millions `M`,
+    whole or 1 decimal (`1,196.3M`).
+  - **Reprice output must list input and output separately**, never merged into one
+    arrow: write `input ¥2.1→¥2.4/M, output ¥8.2→¥9.4/M`, NOT `input ¥2.4/M → ¥9.4/M`.
 
 ## User-visible pricing units
 
@@ -134,12 +153,14 @@ right-size) and is OUT OF SCOPE.
 
 Before any analysis, confirm self-hosting via the API-visible marker: the model
 appears in `list-models --page.search "modelId=maas-"` and its `modelId`
-**starts with** `maas-`. (The `models` API does not expose `source` or
-`resources_requirements`, so the `maas-` prefix is the operative marker;
-`source=BUILTIN` + a running serving + GPU pods are the underlying DB truth.) If
-a model has no `maas-` prefix / no self-hosted serving / its endpoint points at
-an external upstream, **stop** and tell the user it is a resale/pass-through —
-GPU pod cost will not close against it.
+**starts with** `maas-` **or** `a-maas-` (this deployment registers the
+self-hosted models under the `a-maas-` variant — treat it as a `maas-` marker).
+(The `models` API does not expose `source` or `resources_requirements`, so the
+`maas-`/`a-maas-` prefix is the operative marker; `source=BUILTIN` + a running
+serving + GPU pods are the underlying DB truth.) If a model has no
+`maas-`/`a-maas-` prefix / no self-hosted serving / its endpoint points at an
+external upstream, **stop** and tell the user it is a resale/pass-through — GPU
+pod cost will not close against it.
 
 ## Which Playbook
 
@@ -162,10 +183,10 @@ marked by a `maas-` model-id prefix):
 dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json
 ```
 
-Then **client-side keep only** `modelId` that **starts with** `maas-` (the search
-is a contains-match, so it also returns e.g. `test-maas-square` — filter those
-out with a prefix check). The `models` API does not expose `source`; the `maas-`
-prefix is the self-hosted marker. (Do NOT use `maas-models` — that lists knoway
+Then **client-side keep only** `modelId` that **starts with** `maas-` or
+`a-maas-` (the search is a contains-match, so it also returns e.g.
+`test-maas-square` — drop those unrelated hits). The `models` API does not expose
+`source`; the `maas-`/`a-maas-` prefix is the self-hosted marker. (Do NOT use `maas-models` — that lists knoway
 gateway routes and is empty on envs without the knoway gateway installed.)
 
 The following field mapping explains what each pinned command returns. It is
@@ -175,7 +196,8 @@ NOT an invitation to choose other commands.
 |---|---|
 | self-hosted model list | `dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json` |
 | serving replicas | `dce --insecure llm-studio modelservingmanagement list-model-serving -o json` |
-| **token volume + daily series** | `dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time <start>T00:00:00Z --end-time <today>T00:00:00Z --models <model> --period TIME_PERIOD_DAY -o json` → `totalUsage.input`/`output` and daily `dataPoints` |
+| **request model name** (for the usage filter) | `dce --insecure llm-studio adminmodelmanagement get-model --model-id <modelId> -o json` → field `.publicAccessModelName` (e.g. `public/a-maas-deepseek-v4-pro`). This is the exact string the usage API keys on. **Read it; do NOT hardcode / guess the `public/` prefix** — other deployments may use a different scope prefix. |
+| **token volume + daily series** | `dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time <start>T00:00:00Z --end-time <today>T00:00:00Z --models <publicAccessModelName> --period TIME_PERIOD_DAY -o json` → two token-count fields `totalUsage.input` and `totalUsage.output` (the `.input`/`.output` are two separate fields, NOT a division), plus daily `dataPoints`. ⚠️ **The `--models` value MUST be the `publicAccessModelName` from `get-model`** (e.g. `public/a-maas-deepseek-v4-pro`), NOT the bare `modelId`. A **bare modelId returns an empty `dataPoints:[]` / `total:0`** (silent, exit 0) — a wrong-filter artifact, NOT zero demand. Also do NOT drop `--models` to "get everything" — the unfiltered call times out (`context deadline exceeded`). |
 | **sale price** in/out | `dce --insecure billing-center product list-sku-infos --page 1 --page-size 200 --product hydra-maas -o json` → keep items whose `specFields` `model-name` == the model; read the `input` and `output` raw `price`; convert to user-visible `¥/M tokens` with `price / 1000`; revenue = Σ(input_tokens/1,000,000×input_¥_per_M + output_tokens/1,000,000×output_¥_per_M). ⚠️ The product is **always `hydra-maas`**; the model lives in `specFields.model-name`. Do NOT query `--product <model-id>` — it returns empty. **Every self-hosted model HAS input+output prices.** An empty SKU result means you used the wrong product filter — retry with `--product hydra-maas`; never conclude "no SKU / no price / ¥0 revenue / not billed". |
 | **GPU hourly price** | `dce --insecure container-management core get-config-map --cluster kpanda-global-cluster --namespace tokenfactory-system --name tokenfactory-dashboard-resource-cost -o json` → parse `data."resource-cost.yaml"` → `resourceCostSettings.gpus[]` → `{product, price}` (¥/hr). |
 | **utilization** | `dce --insecure operations-management report list-pods --start <YYYY-MM-DD> --end <next-day-after-end> --search <model> -o json` → per-pod GPU util under `data.avgGpuUseRatio` / `data.maxGpuUseRatio` / `data.minGpuUseRatio`; average across the model's pods, `pod count = pagination.total`. Diagnostic signal only. |
@@ -184,12 +206,33 @@ NOT an invitation to choose other commands.
 
 | model_id | GPU product | replicas |
 |---|---|---|
-| `maas-deepseek-v4-pro` | NVIDIA H100 | 4 |
-| `maas-glm-5.1` | NVIDIA H100 | 4 |
-| `maas-qwen3-32b` | NVIDIA H800 | 3 |
-| `maas-minimax-2.7` | NVIDIA A100 | 2 |
+| `a-maas-deepseek-v4-pro` | NVIDIA H200 | 4 |
+| `a-maas-glm-5.1` | NVIDIA B200 | 4 |
+| `a-maas-qwen3-32b` | NVIDIA H100 | 3 |
+| `a-maas-minimax-2.7` | NVIDIA H100 | 2 |
 
-`gpu_cost = replicas × gpu_hourly_price[product] × window_hours` (window_hours = days×24; allocation-based). Replicas above match the serving; you may confirm with `list-model-serving`.
+`gpu_cost = replicas × gpu_hourly_price[product] × window_hours` (allocation-based). Replicas above match the serving; you may confirm with `list-model-serving`.
+
+> ⛔ **Window alignment — the #1 correctness rule (must never be violated).**
+> Revenue and cost MUST cover the **exact same set of complete days**.
+> `window_hours = (number of COMPLETE days actually summed into revenue) × 24`.
+> Never charge a day of GPU cost for a day that has no completed revenue.
+>
+> A day is **complete** only if the whole calendar day has already elapsed —
+> i.e. its date is **strictly before today (UTC)**. **Today is always partial and
+> future dates have not happened**: both return near-zero usage from
+> `usage-statistics2` (it counts only events up to now), so they MUST be dropped
+> from **both** revenue and cost, never counted as "demand collapsed".
+> - Effective last day = `min(requested_end_date, today − 1 day)`.
+> - Effective window = `[start_date, effective_last_day]`; `complete_days =`
+>   that day count; `window_hours = complete_days × 24`.
+> - **Tail-trim check:** drop any trailing day whose total tokens fall below ~20%
+>   of the median of the prior full days — it is an incomplete/partial day, not a
+>   real drop. Re-state the effective coverage window after trimming.
+> - Example: user asks `07-07~07-13`, today = `07-12` → complete days =
+>   `07-07…07-11` (5 days); drop `07-12` (today, partial) and `07-13` (future);
+>   `window_hours = 120`, NOT 168. Using 168h here overstates every loss ~1.4×
+>   and can flip a healthy model (e.g. +15%) to look break-even.
 
 > ⛔ **Data collection is model-bundled, not API-by-API.** First list all
 > self-hosted models once. Then, for each selected model, make one tool call that
@@ -218,7 +261,8 @@ separate tool messages:
 ```text
 model bundle for <model>:
   1. dce --insecure llm-studio modelservingmanagement list-model-serving -o json
-  2. dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time <start>T00:00:00Z --end-time <today>T00:00:00Z --models <model> --period TIME_PERIOD_DAY -o json
+  2a. dce --insecure llm-studio adminmodelmanagement get-model --model-id <modelId> -o json   # read .publicAccessModelName (e.g. public/a-maas-deepseek-v4-pro)
+  2b. dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time <start>T00:00:00Z --end-time <today>T00:00:00Z --models <publicAccessModelName> --period TIME_PERIOD_DAY -o json   # use publicAccessModelName from 2a; bare modelId → empty/0
   3. dce --insecure billing-center product list-sku-infos --page 1 --page-size 200 --product hydra-maas -o json
   4. dce --insecure container-management core get-config-map --cluster kpanda-global-cluster --namespace tokenfactory-system --name tokenfactory-dashboard-resource-cost -o json
   5. dce --insecure operations-management report list-pods --start <start> --end <today+1> --search <model> -o json
@@ -227,7 +271,13 @@ model bundle for <model>:
 Interpretation:
 
 1. Serving list — read this model's `replicas`; client-side filter by model/serving name.
-2. Daily usage — `TIME_PERIOD_DAY` gives BOTH `totalUsage` (window total) and `dataPoints` (per day → latest 7 entries = recent week). Do not make a separate monthly call.
+2. Daily usage — `TIME_PERIOD_DAY` gives BOTH `totalUsage` (window total) and `dataPoints` (per day). Do not make a separate monthly call.
+   - **Revenue: read the two token counts `totalUsage.input` and `totalUsage.output`, then price each and ADD** (the `.input`/`.output` are two separate fields — this is NOT division):
+     `revenue = totalUsage.input / 1,000,000 × input_¥_per_M  +  totalUsage.output / 1,000,000 × output_¥_per_M`.
+     Worked example: `input=1,196,332,723, output=939,156,330, input_price=¥2.1/M, output_price=¥8.2/M` → `1196.33×2.1 + 939.16×8.2 = ¥2,512 + ¥7,701 = ¥10,213`.
+     Because `--end-time` is `<today>T00:00:00Z` (exclusive), the window `[start, today)` is **complete days only**, so `totalUsage` already excludes today's partial day and already sums across all days AND all `modelType` rows. `window_hours = (number of complete days in that window) × 24` for cost. Do NOT hand-sum `dataPoints` for the window total — that is where agents go wrong.
+   - **`dataPoints` are for the daily TREND only.** Each `dataPoint` value is the **per-day** volume (NOT a running/cumulative total): a gently declining `total` across days means demand is declining, it does NOT mean the field is cumulative. The API may emit **multiple rows per day, one per `modelType`** (e.g. `REQUEST_MODEL_TYPE_UNSPECIFIED` + `TEXT_GENERATION`) — **sum ALL modelType rows for that day**; never pick one series and discard the other, and never treat one series as "cumulative" and the other as "incremental".
+   - **Sanity check:** the window token total must be consistent with GPU utilization. A model at ~36% util on 4×H200 does **billions** of tokens/week; if your revenue implies only tens of millions, you dropped a `modelType` series or misread `totalUsage` — recompute from `totalUsage`.
 3. SKU list — client-side filter `specFields.model-name == <model>` → input/output `price`.
 4. GPU price config — read GPU `price` for this model's product using the fixed mapping above.
 5. Pod report — per-pod `data.{avg,max,min}GpuUseRatio`; average across pods; `pod count = pagination.total`.
@@ -253,6 +303,35 @@ GPU cost is **allocation-based**: `gpu_hourly_price × pod-hours`, independent o
 utilization. Prices come from the resource-cost config and the sale-price SKUs;
 use them as given.
 
+## ⛔ Cost & ROI arithmetic audit (mandatory — run before writing any number)
+
+The single most common failure is a wrong cost basis silently flipping a
+loss-making model into a "profit". For **every** model, before stating ROI/margin,
+compute and (in your working) substitute real numbers into exactly these:
+
+```
+gpu_cost = replicas × gpu_hourly_price[CM product for THIS model] × window_hours
+           (window_hours = complete_days × 24)
+margin   = (revenue − gpu_cost) / revenue
+roi      = (revenue − gpu_cost) / gpu_cost          # NOT revenue/gpu_cost
+```
+
+Hard rules — violating any of these is a defect:
+- **Use the CM allocation cost only.** `gpu_cost = replicas × ¥/hr × window_hours`.
+  Do NOT use gmagpie per-pod `gpu_fee`/`list-pods-fee` as the cost, do NOT scale
+  cost by utilization, do NOT use 1 replica or the wrong GPU's price. Each model
+  uses ITS product's price (e.g. GLM-5.1 = B200 ¥50.95/hr, not H200/H100).
+- **`roi = (revenue − gpu_cost)/gpu_cost`, NOT `revenue/gpu_cost`.** The ratio
+  `revenue/gpu_cost = 1 + roi`. Reporting `120.8%` when `revenue/gpu_cost = 1.208`
+  is wrong — that case is `roi = +20.8%`.
+- **Self-consistency assertion (must hold, else recompute):**
+  `roi ≈ margin / (1 − margin)`, and margin & roi must share the **same** revenue
+  and gpu_cost. A negative margin **must** give a negative ROI — a loss-making
+  model can never show positive ROI. If `margin < 0` but you wrote `roi > 0`
+  (or vice-versa), you made an arithmetic error: stop and redo the cost.
+- **Show the substituted cost line** in your working, e.g.
+  `gpu_cost = 4 × ¥17.46/hr × 144h = ¥10,057`, so the reader can re-check it.
+
 ## Rules
 
 - **No fabrication:** every number must come from a pulled query/read result or
@@ -260,9 +339,27 @@ use them as given.
   were read, what came back) before any conclusion.
 - **Ranked hypotheses, not a single root cause:** word it as "likely / leans
   toward / evidence points to," never "the root cause must be X."
-- **Scale-down guardrail:** verify `max_gpu_use_ratio` (peak) < 70% before
-  recommending a scale-down; high util + loss is a pricing signal, not a
-  capacity signal.
+- **Scale-down guardrail — compute the target replica count, don't guess.** A
+  scale-down redistributes load onto the survivors, so peak utilization scales
+  **inversely** with replica count:
+  `post_scale_peak ≈ current_max_gpu_use_ratio × old_replicas / new_replicas`.
+  Pick the **smallest** `new_replicas` that keeps `post_scale_peak < 70%`, i.e.
+  `new_replicas = ceil(current_max_gpu_use_ratio × old_replicas / 70%)`.
+  Never state a replica target without showing this arithmetic.
+  Example: peak 49%, 4 replicas → `ceil(0.49×4/0.70)=ceil(2.8)=3` → recommend
+  **4→3** (post-peak ≈65%), NOT 4→2 (post-peak ≈98%, breaches guardrail).
+  High util + loss is a **pricing** signal, not a capacity signal — do not scale
+  it down.
+- **Reprice magnitude — compute it, don't guess.** For a negative-margin model,
+  the break-even price multiplier is `gpu_cost / revenue` over the same window;
+  the required increase is `(gpu_cost / revenue − 1) × 100%` (raise input/output
+  proportionally, or concentrate on the output SKU). Always show this number.
+  Example: revenue ¥23,481, cost ¥29,347 → `29347/23481 = 1.25` → **+25%**
+  (to break even), not "several times". A margin of −m% needs exactly
+  `m%` more revenue — a −25% margin never needs a 5× price hike.
+  Note this is break-even at constant volume; flag that real elasticity may
+  require a larger raise or partial traffic migration, but never inflate the
+  headline multiple beyond `gpu_cost / revenue`.
 - **ROI ≠ model quality:** any "take traffic" / scale-up suggestion must be
   separately validated for model capability, latency, and error rate.
 - **Don't widen scope:** stay on revenue/cost/utilization/capacity. Don't chase

--- a/skills/ai-inference:llm-roi-analysis/references/playbooks/llm-model-portfolio-roi-analysis.md
+++ b/skills/ai-inference:llm-roi-analysis/references/playbooks/llm-model-portfolio-roi-analysis.md
@@ -8,7 +8,7 @@ Core principles:
 
 - Analysis and recommendation only — never auto-create, scale down, scale up, or shift traffic.
 - Confirm each model is self-hosted first through the model-list read: keep only
-  model IDs that start with `maas-`. Non-`maas-` models are resale/pass-through
+  model IDs that start with `maas-` or `a-maas-`. Other-prefix models are resale/pass-through
   or out of scope for GPU ROI right-sizing.
 - ROI cannot replace model-quality assessment. Any "take traffic" suggestion must additionally verify model capability, business effectiveness, context length, latency, and error rate.
 - On missing data, state which part is missing and which conclusion it affects; do not fabricate mock data to force a conclusion.
@@ -26,11 +26,11 @@ A portfolio diagnosis usually lands in one of the following 4 action classes. Th
 
 ## Data collection (API-first via `dce`)
 
-**Enumerate self-hosted models first** (they carry a `maas-` model-id prefix):
+**Enumerate self-hosted models first** (they carry a `maas-` or `a-maas-` model-id prefix):
 
 ```
 dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json
-# client-side: keep only modelId that startswith "maas-" (search is contains-match)
+# client-side: keep only modelId that startswith "maas-" or "a-maas-" (search is contains-match)
 ```
 
 `maas-models` is NOT the enumeration source — it lists knoway gateway routes and is
@@ -53,11 +53,12 @@ usage-only, SKU-only, utilization-only, or retry narration tool messages.
 ```text
 tool call 0:
   dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json
-  client-side: keep only modelId values that start with maas-
+  client-side: keep only modelId values that start with maas- or a-maas-
 
 tool call 1, model bundle for <model-1>:
   1. dce --insecure llm-studio modelservingmanagement list-model-serving -o json
-  2. dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time <start>T00:00:00Z --end-time <today>T00:00:00Z --models <model-1> --period TIME_PERIOD_DAY -o json
+  2a. dce --insecure llm-studio adminmodelmanagement get-model --model-id <modelId> -o json   # read .publicAccessModelName (the request name; do NOT hardcode the public/ prefix)
+  2b. dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time <start>T00:00:00Z --end-time <today>T00:00:00Z --models <publicAccessModelName> --period TIME_PERIOD_DAY -o json   # use publicAccessModelName from 2a; bare modelId → empty/0 (NOT zero demand). Do not drop --models (times out). If usage=0 but serving RUNNING + util>0, re-check the name from get-model.
   3. dce --insecure billing-center product list-sku-infos --page 1 --page-size 200 --product hydra-maas -o json
   4. dce --insecure container-management core get-config-map --cluster kpanda-global-cluster --namespace tokenfactory-system --name tokenfactory-dashboard-resource-cost -o json
   5. dce --insecure operations-management report list-pods --start <start> --end <today+1> --search <model-1> -o json
@@ -88,7 +89,7 @@ Pinned command outputs used for portfolio rows:
 |---|---|
 | self-hosted model list | model-list read: model IDs starting with `maas-` |
 | replicas | model bundle read 1: serving `replicas`; client-side filter by model/serving name |
-| token volume + daily trend | model bundle read 2: `totalUsage` and daily `dataPoints` |
+| token volume + daily trend | model bundle read 2: **revenue = `totalUsage.input`/1e6 × input_¥/M + `totalUsage.output`/1e6 × output_¥/M** (`totalUsage.input` and `totalUsage.output` are two separate token counts — price each and ADD, this is NOT a division; with `--end-time <today>T00:00:00Z` `totalUsage` already covers complete days only and sums all days + all `modelType` rows — do NOT hand-sum `dataPoints`). `dataPoints` are for the daily trend only: values are per-day (NOT cumulative), and each day may have multiple `modelType` rows (`REQUEST_MODEL_TYPE_UNSPECIFIED` + `TEXT_GENERATION`) that you must **sum**, never pick one. Sanity: nonzero GPU util ⟹ billions of tokens/week, not tens of millions. |
 | input/output sale price | model bundle read 3: hydra-maas SKU where `specFields.model-name` == model |
 | GPU hourly price | model bundle read 4: `resourceCostSettings.gpus[].price`, keyed by fixed GPU product mapping |
 | utilization | model bundle read 5: `data.avgGpuUseRatio`, `data.maxGpuUseRatio`, `data.minGpuUseRatio` |
@@ -101,9 +102,23 @@ The output must state the business window and the **effective coverage window** 
 - Reconcile token usage by `create_time`, earliest and latest usage day.
 - Read utilization from the model bundle pod report for the same business window; if the
   returned data covers fewer days, state the effective coverage window.
-- Do not mix a 29-day cost with 30-day revenue into one ROI. On mismatched
-  coverage days, align calculations to the overlapping returned days; if not
-  alignable from the collected batch, mark reduced confidence in the table.
+- ⛔ **Complete-days-only (must never be violated).** Only **complete** calendar days
+  (date strictly before today, UTC) enter the ROI. **Today is partial and future
+  dates have not happened** — `usage-statistics2` counts events only up to now, so
+  these days come back near-zero. Drop them from **both** revenue and cost; never
+  read them as "demand collapsed".
+  - Effective last day = `min(requested_end_date, today − 1 day)`.
+  - **Tail-trim:** drop any trailing `dataPoints` day whose total tokens are below
+    ~20% of the median of the prior full days (an incomplete day), then re-state
+    the effective coverage window.
+  - `window_hours = complete_days × 24`, where `complete_days` is exactly the set
+    of days summed into revenue.
+- ⛔ **Cost and revenue MUST use the identical complete-day set.** Never pair
+  N-day revenue with (N+k)-day cost. Example: user asks a 7-day window but today is
+  day 6 → revenue and cost both use the 5 complete days (`window_hours = 120`),
+  not 168. Mismatching them overstates every model's loss ~1.4× and can flip a
+  healthy `+15%` model to a false break-even. On any residual mismatch, align to
+  the overlapping complete days; if not alignable, mark reduced confidence.
 
 Each key judgment must cite at least two time points or segments:
 
@@ -147,6 +162,16 @@ deployment_share = model_replicas / portfolio_replicas
 share_gap = cost_share - revenue_share
 ```
 
+⛔ **Cost & ROI audit (mandatory, per model).** `gpu_cost = replicas × ¥/hr[THIS
+model's CM product] × window_hours` — CM allocation only; never gmagpie per-pod
+`gpu_fee`, never utilization-scaled, never the wrong GPU's price (GLM-5.1 = B200
+¥50.95/hr, not H200/H100). `roi = (revenue − gpu_cost)/gpu_cost`, **NOT**
+`revenue/gpu_cost` (that ratio = `1 + roi`). Assert `roi ≈ gross_margin/(1 −
+gross_margin)` with the same revenue & cost; a **negative margin must give a
+negative ROI** — if a model shows loss-margin but positive ROI, the cost is
+wrong, redo it. Show the substituted cost line (e.g. `4 × ¥50.95 × 144 =
+¥29,347`) so it is re-checkable.
+
 Trend metrics, at least first vs last window:
 
 ```text
@@ -169,6 +194,14 @@ Prefer scaling down when:
 - margin down or turned negative;
 - `max_gpu_use_ratio` stays under the scale-down guardrail (peak < 70%) after scale-down.
 
+**Compute the target replica count — never state one without the arithmetic.**
+Peak utilization scales inversely with replicas:
+`post_scale_peak ≈ current_max_gpu_use_ratio × old_replicas / new_replicas`.
+Choose the smallest `new_replicas` with `post_scale_peak < 70%`:
+`new_replicas = ceil(current_max_gpu_use_ratio × old_replicas / 0.70)`.
+Example: peak 49%, 4 replicas → `ceil(0.49×4/0.70)=3` → **4→3** (post-peak ≈65%),
+NOT 4→2 (≈98%, breaches guardrail).
+
 Demo expectation: `deepseek-v4-pro`.
 
 ### Reprice / price-check candidate
@@ -179,6 +212,15 @@ Prefer repricing or a price-check (not direct scale-down) when:
 - utilization high and stable;
 - margin persistently negative;
 - unit cost above current sale price.
+
+**Compute the reprice magnitude — never say "several times" / "N倍" by feel.**
+Break-even multiplier = `gpu_cost / revenue` over the same window; required
+increase = `(gpu_cost / revenue − 1) × 100%`. A `−m%` margin needs exactly
+`m%` more revenue. Example: cost ¥29,347 / revenue ¥23,481 = `1.25` →
+**+25%** to break even (a −25% margin never needs a 5× hike). State this is
+break-even at constant volume; if elasticity is a concern, recommend a phased
+raise or partial traffic migration — but never inflate the headline multiple
+beyond `gpu_cost / revenue`.
 
 Demo expectation: `GLM-5.1`.
 

--- a/skills/ai-inference:llm-roi-analysis/references/playbooks/llm-roi-cost-analysis.md
+++ b/skills/ai-inference:llm-roi-analysis/references/playbooks/llm-roi-cost-analysis.md
@@ -30,7 +30,8 @@ usage-only, SKU-only, utilization-only, or retry narration steps.
 ```text
 tool call 1, model bundle for <model>:
   1. dce --insecure llm-studio modelservingmanagement list-model-serving -o json
-  2. dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time <start>T00:00:00Z --end-time <today>T00:00:00Z --models <model> --period TIME_PERIOD_DAY -o json
+  2a. dce --insecure llm-studio adminmodelmanagement get-model --model-id <modelId> -o json   # read .publicAccessModelName (the request name; do NOT hardcode the public/ prefix)
+  2b. dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time <start>T00:00:00Z --end-time <today>T00:00:00Z --models <publicAccessModelName> --period TIME_PERIOD_DAY -o json   # use publicAccessModelName from 2a; bare modelId → empty/0 (NOT zero demand). Do not drop --models (times out). If usage=0 but serving RUNNING + util>0, re-check the name from get-model; never report "demand collapsed / 空转".
   3. dce --insecure billing-center product list-sku-infos --page 1 --page-size 200 --product hydra-maas -o json
   4. dce --insecure container-management core get-config-map --cluster kpanda-global-cluster --namespace tokenfactory-system --name tokenfactory-dashboard-resource-cost -o json
   5. dce --insecure operations-management report list-pods --start <start> --end <today+1> --search <model> -o json
@@ -50,9 +51,9 @@ tool call 1, model bundle for <model>:
 
 | Need | Field source from the pinned commands |
 |---|---|
-| model source (self-hosted gate) | model-list read: `modelId` starts with `maas-` |
+| model source (self-hosted gate) | model-list read: `modelId` starts with `maas-` or `a-maas-` |
 | serving replicas | bundle read 1: serving `replicas`; client-side filter by model/serving name |
-| **token volume + call time** | bundle read 2: `totalUsage.input` / `totalUsage.output` and daily `dataPoints` |
+| **token volume + call time** | bundle read 2: **revenue = `totalUsage.input`/1e6 × input_¥/M + `totalUsage.output`/1e6 × output_¥/M** (`totalUsage.input` and `totalUsage.output` are two separate token counts — price each and ADD, NOT a division; with `--end-time <today>T00:00:00Z` `totalUsage` covers complete days only and sums all days + all `modelType` rows — do NOT hand-sum `dataPoints`). `dataPoints` are per-day trend only: values are per-day (NOT cumulative), each day may carry multiple `modelType` rows (`REQUEST_MODEL_TYPE_UNSPECIFIED` + `TEXT_GENERATION`) — **sum them**, never pick one series or call one "cumulative". Sanity: nonzero GPU util ⟹ billions of tokens/week. |
 | **sale price** in/out | bundle read 3: SKU `price` where `specFields.model-name` == model; convert `price / 1000` to `¥/M tokens` |
 | **GPU hourly price** | bundle read 4: `resourceCostSettings.gpus[].price`, keyed by fixed GPU product mapping |
 | GPU utilization | bundle read 5: `data.avgGpuUseRatio`, `data.maxGpuUseRatio`, `data.minGpuUseRatio` |
@@ -76,11 +77,30 @@ bundle read 5 pod report      → avg/max/min GPU utilization
 revenue  = Σ( input_tokens/1,000,000 × input_¥_per_M + output_tokens/1,000,000 × output_¥_per_M )
 gpu_cost = Σ_pods( gpu_hourly_price[product] × pod_hours )                            # gpu_hourly_price = resource-cost CM (¥/hr), pod_hours = running hours in window
 margin   = (revenue − gpu_cost) / revenue
-roi      = (revenue − gpu_cost) / gpu_cost
+roi      = (revenue − gpu_cost) / gpu_cost          # NOT revenue/gpu_cost (that ratio = 1 + roi)
 ROI trend = margin this period vs last (period-over-period)
 ```
 
+⛔ **Cost & ROI audit (mandatory).** `gpu_cost = replicas × ¥/hr[CM product] ×
+window_hours` — CM allocation only; never gmagpie per-pod `gpu_fee`, never
+utilization-scaled, never 1 replica or the wrong GPU's price. Assert
+`roi ≈ margin/(1 − margin)` with the same revenue & cost, and a **negative margin
+must give a negative ROI** — a loss-making model can never show positive ROI. If
+they disagree, the cost is wrong: redo it. Report ROI as `(revenue−gpu_cost)/
+gpu_cost`, never `revenue/gpu_cost`. Show the substituted cost line (e.g.
+`4 × ¥17.46 × 144h = ¥10,057`).
+
 > Cost is **allocation-based**: you pay for the reserved GPU whether used or not, so `gpu_cost` does NOT depend on utilization. Utilization is a diagnostic **signal**, never a cost multiplier.
+
+> ⛔ **Window alignment (must never be violated).** `pod_hours` (cost) and the days
+> summed into `revenue` MUST cover the **exact same complete days**. Only days
+> **strictly before today (UTC)** are complete; **today is partial and future dates
+> have not happened** — `usage-statistics2` returns near-zero for them, so drop
+> them from **both** revenue and cost (never read as "demand collapsed").
+> Effective last day = `min(requested_end, today − 1)`; **tail-trim** any trailing
+> day <20% of the prior-day median; then `pod_hours = complete_days × 24`. Never
+> pair N-day revenue with (N+1)-day cost — it overstates the loss and can flip a
+> healthy model to a false break-even.
 
 ## Diagnosis — differential (read signals first, then list possible causes; don't jump to a single verdict)
 
@@ -115,6 +135,21 @@ Before recommending a scale-down, check the **peak** utilization, not the mean:
 if max_gpu_use_ratio (peak) already high (> 70%) → do NOT scale down; a smaller replica count would saturate the survivors.
 high util + loss is a PRICING signal, not a capacity signal.
 ```
+
+**Compute the target replica count — never guess "4→2".** Peak utilization scales
+inversely with replicas: `post_scale_peak ≈ current_max_gpu_use_ratio × old_replicas / new_replicas`.
+Pick the smallest `new_replicas` that keeps `post_scale_peak < 70%`:
+`new_replicas = ceil(current_max_gpu_use_ratio × old_replicas / 0.70)`.
+Always show this arithmetic and the resulting post-scale peak.
+Example: peak 49%, 4 replicas → `ceil(0.49×4/0.70)=3` → recommend **4→3**
+(post-peak ≈66%), NOT 4→2 (post-peak ≈99%, breaches the guardrail). Also state the
+resulting margin at the new replica count (`(revenue − new_cost)/revenue`); do not
+call a strongly-positive result "接近盈亏平衡".
+
+**If the fix is a price change, compute the magnitude — never guess "¥3-4/M" or
+"N倍".** Break-even multiplier = `gpu_cost / revenue` over the same window;
+required increase = `(gpu_cost / revenue − 1) × 100%` (a `−m%` margin needs exactly
+`m%` more revenue). Show the number and which SKU (input/output) you raise.
 
 ## Thresholds (defaults, tunable)
 


### PR DESCRIPTION
## What

Adds correctness guardrails to the `ai-inference:llm-roi-analysis` skill (SKILL.md + both playbooks) to stop a series of recurring analysis errors observed when agents run it against live data.

## Why

Repeated agent runs on the same prompt produced wrong-but-confident results: cost/revenue window mismatch, `4->2` scale-downs that breach the SLA guardrail, "raise price 5x" when +25% breaks even, a loss-making model reported as profitable (wrong GPU price / ROI defined as revenue/cost), "demand collapsed / ROI -100%" from a query artifact, and a catastrophic underread from mishandling the `modelType` split. Each fix below turns a judgement call into a computable, self-checked rule.

## Guardrails added

- **Window alignment** — revenue and cost cover the same complete days; drop today (partial) + future; `window_hours = complete_days x 24`.
- **Scale-down sizing** — `new_replicas = ceil(peak_util x old_replicas / 0.70)`; show the post-scale peak.
- **Reprice magnitude** — break-even `= gpu_cost/revenue - 1`; no guessed multiples.
- **Cost & ROI audit** — `gpu_cost = replicas x CM ¥/hr x window_hours` (allocation only); `roi = (rev-cost)/cost`, not `rev/cost`; negative margin must give negative ROI.
- **Zero-usage sanity** — `usage=0` while serving RUNNING and util>0 is a query artifact, not zero demand.
- **Request model name** — read `publicAccessModelName` from `get-model` for the usage filter; don't hardcode `public/` or pass the bare modelId.
- **Revenue via `totalUsage`** — `totalUsage.input` and `totalUsage.output` are two fields (priced and summed, not a division); `dataPoints` are per-day and may split by `modelType` (sum them).
- **Output precision** — uniform rounding; list input/output reprice separately.

Docs-only; no code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
