### PR TITLE
optimize AI operations and OpenClaw skill workflows

### DIFF
--- a/skills/ai-ops-daily-summary/SKILL.md
+++ b/skills/ai-ops-daily-summary/SKILL.md
@@ -22,6 +22,72 @@ Create a boss-ready daily AI operations summary from DCE / LLM Studio / Hydra da
 
 Use the DCE CLI directly. Prefer `dce` on `PATH`. If a local repository checkout is available, `bin/dce` may also be used. Always request JSON with `-o json` when collecting data.
 
+### Current Environment Fast Path
+
+This environment is currently verified as **CSP mode**. For the normal daily summary, use the CSP fast path first. Do not start by listing workspaces, probing WS endpoints, reading command help, or inspecting raw response schemas.
+
+The fast path must finish data collection in **one orchestration/tool round trip**:
+
+1. Build `start-time`, `end-time`, timezone, and local collection time in memory.
+2. Launch all independent command groups below concurrently (for example, with `Promise.all` when the orchestration tool supports it). Do not wait for one API before starting the next.
+3. Apply `jq` inside each command pipeline so only compact, secret-free summaries return to the model. Never return raw API Key objects.
+4. Compose the report directly from those compact results. Do not run schema-discovery or confirmation calls when the expected fields are present.
+
+Run these command groups concurrently:
+
+| Group | Commands | Return only |
+|---|---|---|
+| Usage + price | `get-api-key-usage-statistics2` and `modelmanagement list-models --show-public-model-price` | total input/output/Token, per-model usage, per-model calculated charge, price coverage, peak hour, latest timestamp |
+| API Key governance | `apikeymanagement list-api-key` | total, disabled, expired, zero-quota, unlimited, never-used, stale/latest-use counts; never return `key` |
+| Model serving | `modelservingmanagement list-model-serving` | total and status counts |
+| Model supply | `maasservice list-maas-models` | total, enabled count, gateway-status counts |
+| Active alerts | `insight alert list-alerts --all` | total, severity/status counts, compact CRITICAL/WARNING rule summaries |
+| Clock | local `date` | collection cutoff in the user's timezone |
+
+Usage and model prices are the only dependent pair. Fetch both within the same concurrent group and join them locally with `jq -s`; do not make a second API round after usage returns. Other groups must run in parallel with that pair.
+
+The fast path is successful when the usage call returns `totalUsage`, even if another optional group fails. Keep successful partial data and produce the summary. Enter runtime-mode detection only when a primary CSP endpoint returns `SYSTEM-REQUEST_MODE_ERROR`, a mode-specific `404`, or an incompatible response shape.
+
+Do not confuse one orchestration round trip with one server API. The current DCE runtime exposes separate read APIs; the speedup comes from launching them together and returning compact aggregates once.
+
+### Runtime Mode Detection (Fallback Only)
+
+Use this section only when the current-environment CSP fast path fails because the runtime mode appears to have changed. Do not run it on every daily summary.
+
+1. List visible workspaces for context:
+
+   ```bash
+   dce container-management workspace list-workspaces -o json
+   ```
+
+2. Probe one read-only workspace endpoint with the first visible workspace ID:
+
+   ```bash
+   dce llm-studio wsdashboardmanagement get-ws-dashboard-summary \
+     --workspace <workspace-id> \
+     --start-time '<start-time>' \
+     --end-time '<end-time>' \
+     --timezone '<timezone>' \
+     -o json
+   ```
+
+3. Probe one read-only CSP endpoint:
+
+   ```bash
+   dce llm-studio apikeymanagement list-api-key \
+     --page.page-size -1 \
+     -o json
+   ```
+
+Classify the runtime from actual responses:
+
+- **WS mode:** the workspace dashboard probe succeeds. Use the WS collection path below.
+- **CSP mode:** the CSP probe succeeds while WS endpoints return `SYSTEM-REQUEST_MODE_ERROR` or mode-specific `404`. Use the CSP collection path below and do not retry every WS endpoint.
+- **Mixed mode:** both probes succeed. Collect both paths, deduplicate overlapping metrics, and label the source scope.
+- **Undetermined:** neither probe succeeds. Keep only other successful `Any` or Insight data and state the material coverage gap.
+
+Messages such as `Current API mode: CSP` or `Current API mode: WS` in command help describe the command's required mode; they are not proof of the server's active mode. A successful read-only probe is the deciding evidence.
+
 For "today", build the time window in the user's timezone. Example for Beijing time:
 
 ```text
@@ -30,7 +96,9 @@ end-time:   YYYY-MM-DDT23:59:59+08:00
 timezone:   Asia/Shanghai
 ```
 
-Run these commands:
+### WS Mode Collection
+
+Run these commands only when the WS probe succeeds:
 
 ```bash
 # 1. Visible workspaces
@@ -90,6 +158,76 @@ dce llm-studio adminmodelmanagement list-models \
   -o json
 ```
 
+### CSP Mode Collection
+
+In CSP mode, use global LLM Studio resources instead of workspace-prefixed resources:
+
+```bash
+# 1. Global API Key inventory and token usage
+dce llm-studio apikeymanagement list-api-key \
+  --page.page-size -1 \
+  -o json
+
+dce llm-studio apikeymanagement get-api-key-usage-statistics2 \
+  --start-time '<start-time>' \
+  --end-time '<end-time>' \
+  --period TIME_PERIOD_HOUR \
+  -o json
+
+# 2. Global model inventory, published prices, and serving state
+dce llm-studio modelmanagement list-models \
+  --page.page-size -1 \
+  --show-public-model-price \
+  -o json
+
+dce llm-studio modelservingmanagement list-model-serving \
+  --page.page-size -1 \
+  -o json
+
+# 3. Platform model supply
+dce llm-studio maasservice list-maas-models \
+  --page.page-size -1 \
+  -o json
+
+dce llm-studio adminmodelmanagement list-models \
+  --page.page-size -1 \
+  --show-deploy-template \
+  --selector ALL \
+  -o json
+
+# 4. Current platform alerts
+dce insight alert list-alerts \
+  --all \
+  -o json
+```
+
+In CSP mode:
+
+- Use `totalUsage.input`, `totalUsage.output`, and `totalUsage.total` from the global API Key usage statistics as the consumption totals.
+- Aggregate `dataPoints` by `model` and `timestamp` for model shares, hourly trends, and the latest completed data point.
+- Use global API Key inventory only for governance counts. Do not infer active-user or active-key counts from aggregate token data.
+- Do not call `workspacequotaservice` or other WS-only resources after the runtime has been identified as CSP unless a mixed-mode probe proves they work.
+- Do not describe global CSP metrics as workspace totals or tenant rankings.
+
+### Cost Calculation
+
+Calculate cost only when both model-level token usage and matching model prices are returned in the current run:
+
+```text
+model cost = input_tokens / 1000 * inputPerKTokens
+           + output_tokens / 1000 * outputPerKTokens
+total cost = sum(model cost)
+```
+
+- Join usage model names such as `public/<model-id>` to the corresponding model price.
+- If any used model lacks a price, report only the priced subset and its coverage; do not present it as the total cost.
+- If the API does not return a currency, label the result as `pricing units` (or the user's language equivalent), never as CNY, USD, or another currency.
+- Treat the result as calculated/estimated cost and state the formula briefly.
+
+### Collection Cutoff
+
+For an in-progress day, record the local collection time and the maximum returned usage timestamp. Describe figures as `as of <time>`, not as a completed full-day total. If the requested end time is later than the collection time, do not imply that future hours are covered.
+
 If a DCE CLI command returns 404 or fails, keep the partial data and mention any material gap only if it affects confidence. Do not include metrics from failed commands.
 
 ## Business Value Data
@@ -112,22 +250,29 @@ Hydra is usually exposed through `dce llm-studio ...` commands. If a separate `h
 
 ## Summary Workflow
 
-1. Query visible workspaces first, then run all per-workspace commands for each workspace.
-2. Aggregate across all visible workspaces.
-3. Prioritize conclusions in this order:
+1. Build the requested local-day time window and record the collection time.
+2. Run the current-environment CSP fast path in one concurrent orchestration round and aggregate before returning data to the model.
+3. If the primary CSP usage endpoint succeeds, skip mode probes, workspace discovery, command help, and response-shape inspection. Continue directly to conclusions.
+4. Only if the CSP fast path indicates a mode change, detect WS, CSP, mixed, or undetermined mode with the fallback read-only probes.
+5. On fallback, collect only the command path supported by the detected mode:
+   - WS: query visible workspaces and aggregate successful per-workspace results.
+   - CSP: query global API Key usage, global models, model serving, MAAS supply, and active alerts.
+   - Mixed: collect both and explicitly deduplicate overlapping usage totals.
+6. Report the source scope (`workspace aggregate`, `global CSP`, or `mixed`) and the latest usage timestamp when the day is still in progress.
+7. Prioritize conclusions in this order:
    - Actual consumption: request count, total/input/output tokens, active users.
    - Adoption: active users vs total users, workspace coverage.
    - Supply readiness: public/MAAS models enabled and gateway health.
-   - Deployment posture: workspace model-serving count.
+   - Deployment posture: model-serving count and status in the detected scope.
    - Governance and waste: API Key count, zero-quota keys, never-used keys, stale keys, disabled/expired keys.
-4. For business-value requests, add retrieved operating-value signals in this order:
+8. For business-value requests, add retrieved operating-value signals in this order:
    - Capacity utilization and cumulative Token output.
    - Revenue, cost, gross profit, margin, and ROI only when measured or calculable from retrieved inputs.
    - Tenant/API Key concentration and quota risk.
    - Model supply and model-serving readiness.
    - Retrieved risk suggestions and alerts.
-5. Keep up to 5 conclusions. Fewer is better than adding unsupported conclusions.
-6. Present the output as Markdown tables when the user wants a direct/visual view.
+9. Keep up to 5 conclusions. Fewer is better than adding unsupported conclusions.
+10. Present the output as Markdown tables when the user wants a direct/visual view.
 
 ## Output Format
 
@@ -142,6 +287,8 @@ Rules:
 - Use only values retrieved through DCE CLI commands in the current run.
 - Omit any metric, finding, cause, or recommendation that is not backed by retrieved DCE CLI data.
 - If data is incomplete, explicitly say `Based on the currently available DCE CLI data`.
+- State the detected runtime mode and metric scope when they affect interpretation.
+- For an in-progress day, include the local collection cutoff or latest returned usage timestamp.
 - Match the user's language in the final answer, but keep these skill instructions in English.
 - Do not expose raw API keys or secrets; only count keys and summarize status.
 
@@ -223,9 +370,14 @@ Optional detail tables may be added under the required sections only when they m
 - If public models are enabled and gateway status is healthy, describe supply as ready or available.
 - If workspace model-serving count is zero, describe the posture as public-model driven rather than self-deployed/private-serving driven.
 - For API Keys, count total, disabled, expired, zero-quota, never-used (`lastUsedTime` missing), and stale keys. Do not print the key values.
+- In CSP mode, a global usage total does not prove which API Keys were active. Report aggregate consumption and inventory metadata separately unless per-key usage was retrieved.
+- If global usage is nonzero while every listed API Key reports zero quota, zero used quota, or stale `lastUsedTime`, describe this as a metering/attribution consistency risk that needs reconciliation. Do not claim quota bypass or identify a responsible Key without per-key evidence.
+- Count active alerts by severity and firing status. A retrieved firing `CRITICAL` alert may set the overall risk to Critical even when all model-serving records are RUNNING; distinguish platform reliability risk from model-serving availability.
 - Use concrete workspace names and IDs only when they clarify the conclusion; otherwise aggregate for leadership readability.
 - Do not infer business risk from missing data. A missing quota response is not a budget risk; a missing cost response is not zero cost; a missing department endpoint is not zero department usage.
+- In CSP mode, omit request counts, active-user counts, workspace allocation, and workspace quotas unless a successful command explicitly returned them.
 - If department token usage is unsupported in the current runtime mode, omit department rankings and base the summary on tenant/API Key/workspace data that was retrieved.
 - Capacity risk must be grounded in retrieved throughput, rated capacity, GPU utilization, node metrics, or explicit bottleneck forecast data.
 - Financial conclusions require retrieved revenue/cost/profit data or retrieved token usage plus retrieved price/cost configuration. Otherwise omit financial metrics.
+- A calculated token charge is not infrastructure cost, gross profit, or ROI. Use the returned price units and currency metadata exactly; if currency is absent, say `pricing units`.
 - Risk recommendations must map to retrieved evidence: quota exhaustion, low utilization, traffic drop, concentration, alert/security event, or explicit risk-suggestion API output.

--- a/skills/openclaw-request-rca/SKILL.md
+++ b/skills/openclaw-request-rca/SKILL.md
@@ -35,6 +35,41 @@ Prefer direct DCE CLI queries and JSON output. Do not infer root cause from a si
 
 Follow this order. Do not jump directly from an alert to a root cause without checking the OpenClaw request span.
 
+### Fast Path: One Terminal Call
+
+For a normal "recent OpenClaw analysis" request, use the bundled collector first. It performs the necessary DCE API calls concurrently and returns compact NDJSON containing cluster inventory, strictly filtered OpenClaw spans, errors, R.E.D metrics, pods, and alerts:
+
+```bash
+bash scripts/collect_rca.sh 24 1s
+```
+
+Resolve `scripts/collect_rca.sh` relative to this `SKILL.md`. The arguments are:
+
+1. lookback hours, default `24`;
+2. slow threshold, default `1s`;
+3. optional cluster name.
+
+Efficiency rules:
+
+- Prefer this single collector invocation over sequential terminal calls.
+- Do not call `get-tag-values` namespace-by-namespace on the normal path. The collector discovers namespaces from Kubernetes inventory and trace services, then applies the required OpenClaw tag directly to span queries.
+- Do not rerun commands merely to reformat JSON; aggregate with `jq` inside the collector call.
+- If no OpenClaw spans are found, use the collector's workload, metrics, Collector, and alert evidence to classify `no traffic` versus `telemetry gap`. Broaden the window only when the user needs the last-known activity time.
+- The collector also fetches error spans, slow spans, and aggregate Jaeger details for up to three priority traces per OpenClaw namespace. Do not make a second terminal call for data already present in its output.
+- Make one follow-up terminal call only when relevant container logs are required, an API failed, evidence was truncated, or the user supplies a new trace ID or incident window. Fetch every required log/detail concurrently in that call.
+
+The collector overlaps independent work:
+
+1. Run namespace inventory and trace-service discovery concurrently with Pod, alert, and metric collection.
+2. Start strictly filtered span discovery as soon as namespace prerequisites finish; do not wait for platform correlation APIs.
+3. Query error and slow spans concurrently for every discovered OpenClaw namespace.
+4. Fetch priority trace details concurrently while platform collection finishes.
+5. Join all results once, then emit compact aggregates instead of full raw alert/span payloads.
+
+When the user supplies a cluster, pass it as the third argument so the collector skips cluster discovery.
+
+Target latency for the first-pass analysis is under 60 seconds in a normally responsive DCE environment.
+
 1. Identify the OpenClaw trace namespace and service by locating `otel.scope.name=openclaw-otel-plugin`.
 2. Query OpenClaw error spans in the incident window.
 3. Query slow OpenClaw spans in the same window.
@@ -102,42 +137,22 @@ kpanda-global-cluster
 
 ### 2. Discover the OpenClaw Namespace
 
-Query `otel.scope.name` values per namespace that has trace services.
+Use `scripts/collect_rca.sh`; it already performs namespace discovery. Do not run separate terminal commands for this section on the normal path.
 
-Important: namespace discovery is only a way to find where OpenClaw spans may live. A namespace can contain many unrelated application traces, so never treat all traces in the selected namespace as OpenClaw data. Every OpenClaw span query and every interpretation of span output must continue to filter by:
+The collector:
+
+1. fetches clusters, Kubernetes namespaces, and trace services concurrently;
+2. merges Kubernetes and tracing namespaces so it can include namespaces with traces but no current Pod;
+3. queries every candidate namespace concurrently with the required span filter;
+4. emits only namespaces whose filtered result contains OpenClaw spans.
+
+Namespace discovery only identifies candidates. A namespace can contain unrelated traces, so every OpenClaw query and interpretation must retain:
 
 ```text
 otel.scope.name=openclaw-otel-plugin
 ```
 
-```bash
-END=$(date -u +%s)000
-
-dce insight tracing get-services \
-  --cluster-name <cluster-name> \
-  --lookback 86400000 \
-  --end-time "$END" \
-  --span-kinds SPAN_KIND_SERVER \
-  --sort 'reqRate,desc' \
-  --page 1 \
-  --page-size 200 \
-  -o json
-```
-
-Then for each candidate namespace:
-
-```bash
-dce insight tracing get-tag-values \
-  --name otel.scope.name \
-  --cluster <cluster-name> \
-  --namespace <namespace> \
-  --limit 1000 \
-  -o json
-```
-
-Select the namespace where `openclaw-otel-plugin` appears. In observed environments this may be a workload namespace such as `jinye-ns`, not a platform namespace.
-
-If multiple namespaces contain `openclaw-otel-plugin`, query each candidate with the strict tag filter and use only the namespace whose filtered spans match the reported incident window, service, operation, or trace ID. Do not select a namespace based on request volume alone, because high-volume non-OpenClaw services can appear in the same namespace.
+If the collector returns multiple OpenClaw namespaces, analyze each independently and select by the reported incident window, service, operation, or trace ID. Never select by namespace request volume alone. Use manual namespace discovery only when the collector reports an API failure.
 
 ### 3. Query OpenClaw Spans
 

--- a/skills/openclaw-request-rca/scripts/collect_rca.sh
+++ b/skills/openclaw-request-rca/scripts/collect_rca.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Collect the complete first-pass OpenClaw RCA data set in one terminal call.
+# The DCE API calls are executed concurrently; output is compact NDJSON so the
+# caller can reason over it without reading large raw payloads.
+
+HOURS="${1:-24}"
+SLOW_THRESHOLD="${2:-1s}"
+CLUSTER_FILTER="${3:-}"
+PARALLELISM="${OPENCLAW_RCA_PARALLELISM:-12}"
+SPAN_PAGE_SIZE="${OPENCLAW_RCA_SPAN_PAGE_SIZE:-100}"
+
+command -v dce >/dev/null
+command -v jq >/dev/null
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-rca.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+END_EPOCH="$(date -u +%s)"
+START_EPOCH="$((END_EPOCH - HOURS * 3600))"
+END_RFC3339="$(date -u -r "$END_EPOCH" '+%Y-%m-%dT%H:%M:%SZ')"
+START_RFC3339="$(date -u -r "$START_EPOCH" '+%Y-%m-%dT%H:%M:%SZ')"
+END_MILLIS="$((END_EPOCH * 1000))"
+LOOKBACK_MILLIS="$((HOURS * 3600000))"
+
+if [[ -n "$CLUSTER_FILTER" ]]; then
+  printf '%s\n' "$CLUSTER_FILTER" >"$WORK_DIR/cluster_names.txt"
+else
+  dce container-management cluster list-clusters --page-size 100 -o json >"$WORK_DIR/clusters.json"
+  jq -r '.items[].metadata.name' "$WORK_DIR/clusters.json" >"$WORK_DIR/cluster_names.txt"
+fi
+
+if [[ ! -s "$WORK_DIR/cluster_names.txt" ]]; then
+  jq -nc --arg error "No matching DCE cluster" --arg cluster "$CLUSTER_FILTER" \
+    '{type:"error",error:$error,cluster:$cluster}'
+  exit 2
+fi
+
+collect_cluster_inventory() {
+  local cluster="$1"
+  local safe_cluster="${cluster//[^A-Za-z0-9_.-]/_}"
+
+  dce container-management core list-cluster-namespaces \
+    --cluster "$cluster" --page-size 500 -o json >"$WORK_DIR/namespaces.$safe_cluster.json" &
+  DISCOVERY_PIDS+=("$!")
+  dce insight tracing get-services \
+    --cluster-name "$cluster" --lookback "$LOOKBACK_MILLIS" --end-time "$END_MILLIS" \
+    --sort 'reqRate,desc' --page 1 --page-size 500 -o json >"$WORK_DIR/services.$safe_cluster.json" &
+  DISCOVERY_PIDS+=("$!")
+  dce insight resource list-pods \
+    --cluster "$cluster" --page-size 500 -o json >"$WORK_DIR/pods.$safe_cluster.json" &
+  PLATFORM_PIDS+=("$!")
+  dce insight alert list-alerts \
+    --cluster-name "$cluster" --page-size 100 --sorts startsAt,desc -o json >"$WORK_DIR/alerts.$safe_cluster.json" &
+  PLATFORM_PIDS+=("$!")
+  dce insight metric query-metric \
+    --cluster-name "$cluster" --time "$END_EPOCH" \
+    --query 'sum(increase(openclaw_requests_total['"$HOURS"'h])) by (openclaw_outcome,openclaw_final_state,channel,job)' \
+    -o json >"$WORK_DIR/metrics.$safe_cluster.json" &
+  PLATFORM_PIDS+=("$!")
+}
+
+DISCOVERY_PIDS=()
+PLATFORM_PIDS=()
+while IFS= read -r cluster; do
+  collect_cluster_inventory "$cluster"
+done <"$WORK_DIR/cluster_names.txt"
+
+# Namespace/service discovery is the only prerequisite for span queries.
+# Keep pod, alert, and metric calls running while the trace path proceeds.
+for pid in "${DISCOVERY_PIDS[@]}"; do
+  wait "$pid"
+done
+
+# Build cluster/namespace pairs from both Kubernetes inventory and tracing
+# services. This avoids slow tag-value discovery and still covers namespaces
+# that no longer have a running Pod but have traces inside the requested window.
+: >"$WORK_DIR/pairs.tsv"
+while IFS= read -r cluster; do
+  safe_cluster="${cluster//[^A-Za-z0-9_.-]/_}"
+  {
+    jq -r '.items[]?.metadata.name // empty' "$WORK_DIR/namespaces.$safe_cluster.json"
+    jq -r '.items[]?.namespace // empty' "$WORK_DIR/services.$safe_cluster.json"
+  } | sort -u | awk -v cluster="$cluster" 'NF {print cluster "\t" $0}' >>"$WORK_DIR/pairs.tsv"
+done <"$WORK_DIR/cluster_names.txt"
+
+export WORK_DIR START_RFC3339 END_RFC3339 SLOW_THRESHOLD SPAN_PAGE_SIZE
+xargs -P "$PARALLELISM" -n 2 bash -c '
+  cluster="$1"
+  namespace="$2"
+  safe_cluster="${cluster//[^A-Za-z0-9_.-]/_}"
+  safe_namespace="${namespace//[^A-Za-z0-9_.-]/_}"
+  jq -nc \
+    --arg cluster "$cluster" --arg namespace "$namespace" \
+    --arg start "$START_RFC3339" --arg end "$END_RFC3339" \
+    --argjson pageSize "$SPAN_PAGE_SIZE" \
+    "{clusterName:\$cluster,namespace:\$namespace,start:\$start,end:\$end,sort:\"duration,desc\",page:1,pageSize:\$pageSize,tags:[{key:\"otel.scope.name\",operation:\"EQUAL\",value:\"openclaw-otel-plugin\"}]}" \
+    | dce insight tracing query-spans --file - -o json \
+      >"$WORK_DIR/spans.$safe_cluster.$safe_namespace.json"
+' _ <"$WORK_DIR/pairs.tsv"
+
+# Query errors only for namespaces that actually contain OpenClaw spans.
+: >"$WORK_DIR/openclaw_pairs.tsv"
+while IFS=$'\t' read -r cluster namespace; do
+  safe_cluster="${cluster//[^A-Za-z0-9_.-]/_}"
+  safe_namespace="${namespace//[^A-Za-z0-9_.-]/_}"
+  span_file="$WORK_DIR/spans.$safe_cluster.$safe_namespace.json"
+  if [[ "$(jq '.pagination.total // (.items | length) // 0' "$span_file")" -gt 0 ]]; then
+    printf '%s\t%s\n' "$cluster" "$namespace" >>"$WORK_DIR/openclaw_pairs.tsv"
+  fi
+done <"$WORK_DIR/pairs.tsv"
+
+if [[ -s "$WORK_DIR/openclaw_pairs.tsv" ]]; then
+  xargs -P "$PARALLELISM" -n 2 bash -c '
+    cluster="$1"
+    namespace="$2"
+    safe_cluster="${cluster//[^A-Za-z0-9_.-]/_}"
+    safe_namespace="${namespace//[^A-Za-z0-9_.-]/_}"
+    jq -nc \
+      --arg cluster "$cluster" --arg namespace "$namespace" \
+      --arg start "$START_RFC3339" --arg end "$END_RFC3339" --argjson pageSize "$SPAN_PAGE_SIZE" \
+      "{clusterName:\$cluster,namespace:\$namespace,start:\$start,end:\$end,onlyErrorSpans:true,sort:\"startTime,desc\",page:1,pageSize:\$pageSize,tags:[{key:\"otel.scope.name\",operation:\"EQUAL\",value:\"openclaw-otel-plugin\"}]}" \
+      | dce insight tracing query-spans --file - -o json \
+        >"$WORK_DIR/errors.$safe_cluster.$safe_namespace.json" &
+    jq -nc \
+      --arg cluster "$cluster" --arg namespace "$namespace" \
+      --arg start "$START_RFC3339" --arg end "$END_RFC3339" --arg durationMin "$SLOW_THRESHOLD" --argjson pageSize "$SPAN_PAGE_SIZE" \
+      "{clusterName:\$cluster,namespace:\$namespace,start:\$start,end:\$end,durationMin:\$durationMin,sort:\"duration,desc\",page:1,pageSize:\$pageSize,tags:[{key:\"otel.scope.name\",operation:\"EQUAL\",value:\"openclaw-otel-plugin\"}]}" \
+      | dce insight tracing query-spans --file - -o json \
+        >"$WORK_DIR/slow.$safe_cluster.$safe_namespace.json" &
+    wait
+  ' _ <"$WORK_DIR/openclaw_pairs.tsv"
+
+  # Fetch aggregate Jaeger trace metadata for the most important traces in the
+  # same invocation: errors first, then the slowest traces, at most 3 per
+  # OpenClaw namespace.
+  : >"$WORK_DIR/trace_pairs.tsv"
+  while IFS=$'\t' read -r cluster namespace; do
+    safe_cluster="${cluster//[^A-Za-z0-9_.-]/_}"
+    safe_namespace="${namespace//[^A-Za-z0-9_.-]/_}"
+    {
+      jq -r '.items[]?.traceId // empty' "$WORK_DIR/errors.$safe_cluster.$safe_namespace.json"
+      jq -r '.items[]?.traceId // empty' "$WORK_DIR/slow.$safe_cluster.$safe_namespace.json"
+    } | awk '!seen[$0]++ && count++ < 3' | awk -v cluster="$cluster" -v namespace="$namespace" '{print cluster "\t" namespace "\t" $0}' \
+      >>"$WORK_DIR/trace_pairs.tsv"
+  done <"$WORK_DIR/openclaw_pairs.tsv"
+
+  if [[ -s "$WORK_DIR/trace_pairs.tsv" ]]; then
+    xargs -P "$PARALLELISM" -n 3 bash -c '
+      cluster="$1"
+      namespace="$2"
+      trace_id="$3"
+      safe_cluster="${cluster//[^A-Za-z0-9_.-]/_}"
+      safe_namespace="${namespace//[^A-Za-z0-9_.-]/_}"
+      dce insight tracing find-jaeger-trace \
+        --trace-id "$trace_id" --cluster-name "$cluster" --namespace "$namespace" -o json \
+        >"$WORK_DIR/trace.$safe_cluster.$safe_namespace.$trace_id.json"
+    ' _ <"$WORK_DIR/trace_pairs.tsv"
+  fi
+fi
+
+# Platform correlation is independent of trace drill-down. Join it only before
+# composing the final records.
+for pid in "${PLATFORM_PIDS[@]}"; do
+  wait "$pid"
+done
+
+jq -nc \
+  --arg start "$START_RFC3339" --arg end "$END_RFC3339" \
+  --argjson hours "$HOURS" --arg slowThreshold "$SLOW_THRESHOLD" \
+  '{type:"meta",start:$start,end:$end,hours:$hours,slowThreshold:$slowThreshold,spanFilter:"otel.scope.name=openclaw-otel-plugin"}'
+
+while IFS= read -r cluster; do
+  safe_cluster="${cluster//[^A-Za-z0-9_.-]/_}"
+  jq -nc \
+    --arg cluster "$cluster" \
+    --slurpfile services "$WORK_DIR/services.$safe_cluster.json" \
+    --slurpfile pods "$WORK_DIR/pods.$safe_cluster.json" \
+    --slurpfile alerts "$WORK_DIR/alerts.$safe_cluster.json" \
+    --slurpfile metrics "$WORK_DIR/metrics.$safe_cluster.json" \
+    '{type:"cluster",cluster:$cluster,
+      traceServiceCount:($services[0].pagination.total // ($services[0].items|length) // 0),
+      openclawMetrics:($metrics[0].vector // []),
+      podSummary:{total:($pods[0].pagination.total // ($pods[0].items|length) // 0),notReady:[ $pods[0].items[]? | select((.phase == "POD_PHASE_PENDING" or .phase == "POD_PHASE_UNKNOWN" or .phase == "POD_PHASE_FAILED") or (.phase == "POD_PHASE_RUNNING" and .containerNumSummary.readyNum != .containerNumSummary.totalNum)) | {namespace,name,phase,ready:.containerNumSummary,restarts:.restartCount}]},
+      alertSummary:{
+        total:($alerts[0].pagination.total // ($alerts[0].items|length) // 0),
+        bySeverity:([$alerts[0].items[]? | .severity] | group_by(.) | map({severity:.[0],count:length})),
+        byRule:([$alerts[0].items[]? | {ruleName,severity,status,namespace,startAt,description}]
+          | group_by([.ruleName,.severity,.namespace,.status])
+          | map({ruleName:.[0].ruleName,severity:.[0].severity,status:.[0].status,namespace:.[0].namespace,count:length,
+            latestStartAt:(map(.startAt|tonumber)|max|tostring),descriptions:(map(.description)|map(select(length>0))|unique|.[0:3])}))}
+      }
+    '
+done <"$WORK_DIR/cluster_names.txt"
+
+if [[ ! -s "$WORK_DIR/openclaw_pairs.tsv" ]]; then
+  jq -nc '{type:"openclaw",found:false,spanCount:0,errorSpanCount:null,classification:"no_traffic_or_telemetry_gap"}'
+  exit 0
+fi
+
+while IFS=$'\t' read -r cluster namespace; do
+  safe_cluster="${cluster//[^A-Za-z0-9_.-]/_}"
+  safe_namespace="${namespace//[^A-Za-z0-9_.-]/_}"
+  jq -nc \
+    --arg cluster "$cluster" --arg namespace "$namespace" \
+    --slurpfile spans "$WORK_DIR/spans.$safe_cluster.$safe_namespace.json" \
+    --slurpfile errors "$WORK_DIR/errors.$safe_cluster.$safe_namespace.json" \
+    --slurpfile slow "$WORK_DIR/slow.$safe_cluster.$safe_namespace.json" \
+    '{type:"openclaw",found:true,cluster:$cluster,namespace:$namespace,
+      spanCount:($spans[0].pagination.total // ($spans[0].items|length) // 0),
+      errorSpanCount:($errors[0].pagination.total // ($errors[0].items|length) // 0),
+      slowSpanCount:($slow[0].pagination.total // ($slow[0].items|length) // 0),
+      slowest:[$slow[0].items[:10][]? | {traceId,spanId,serviceName,operationName,duration,startTime,status,method,protocol}],
+      errors:[$errors[0].items[:10][]? | {traceId,spanId,serviceName,operationName,duration,startTime,status,method,protocol}]}'
+done <"$WORK_DIR/openclaw_pairs.tsv"
+
+if [[ -s "$WORK_DIR/trace_pairs.tsv" ]]; then
+  while IFS=$'\t' read -r cluster namespace trace_id; do
+    safe_cluster="${cluster//[^A-Za-z0-9_.-]/_}"
+    safe_namespace="${namespace//[^A-Za-z0-9_.-]/_}"
+    jq -nc \
+      --arg cluster "$cluster" --arg namespace "$namespace" --arg traceId "$trace_id" \
+      --slurpfile detail "$WORK_DIR/trace.$safe_cluster.$safe_namespace.$trace_id.json" \
+      '{type:"traceDetail",cluster:$cluster,namespace:$namespace,traceId:$traceId,
+        traces:[$detail[0].traces[]? | {traceId,operationName,duration,startTime,status,statusCode,spanCount,warnings,
+          processes:[.processMap[]?.process | {serviceName,tags:[.tags[]? | select(.key == "agent_runtime" or .key == "agent_version" or .key == "k8s.namespace.name" or .key == "service.namespace" or .key == "process.runtime.version" or .key == "runtime_environment") | {key,value:(.vStr // .vInt64 // .vFloat64 // .vBool)}]}]}]}'
+  done <"$WORK_DIR/trace_pairs.tsv"
+fi


### PR DESCRIPTION
## What changed

- add a CSP fast path and runtime-mode fallback guidance to the AI operations daily summary skill
- add cost, cutoff-time, metric-scope, governance, and alert interpretation guardrails
- add a concurrent OpenClaw RCA collector and update the skill to prefer a one-terminal-call fast path

## Why

The existing workflows required more sequential discovery calls than necessary and could overstate conclusions when runtime mode, pricing coverage, or attribution data was incomplete. The new collector and guidance reduce first-pass latency while keeping conclusions tied to retrieved evidence.

## Impact

- faster daily AI operations summaries in verified CSP environments
- faster first-pass OpenClaw request analysis through concurrent DCE queries
- clearer reporting boundaries for partial data, costs, alerts, and in-progress daily totals

## Validation

- `go test ./...`
- `bash -n skills/openclaw-request-rca/scripts/collect_rca.sh`
- `shellcheck -e SC2016 skills/openclaw-request-rca/scripts/collect_rca.sh` (SC2016 is intentionally excluded because variables inside the single-quoted `bash -c` programs expand in the child shell)
