### PR TITLE
fix(llm-roi-analysis): single-command data collection + output shrink

### DIFF
--- a/skills/ai-inference:llm-roi-analysis/SKILL.md
+++ b/skills/ai-inference:llm-roi-analysis/SKILL.md
@@ -265,9 +265,9 @@ run it once; then parse the labelled `### SECTION` blocks from the single output
 
 ```bash
 M="<modelId>"; S="<start-date>"; E="<today-date>"   # e.g. M=a-maas-deepseek-v4-pro S=2026-07-08 E=2026-07-15
-# publicAccessModelName is captured with grep (do NOT pipe to `python -c` — the harness blocks -c scripts)
+# publicAccessModelName is extracted as its complete API-returned value (do NOT pipe to `python -c` — the harness blocks -c scripts)
 echo "### MODELS"; dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json | grep '"modelId"'   # enumerate + self-hosted gate, grepped tiny; replaces any separate list-models call
-PUB=$(dce --insecure llm-studio adminmodelmanagement get-model --model-id "$M" -o json | grep -o '"publicAccessModelName" *: *"[^"]*"' | grep -o 'public/[^"]*')
+PUB=$(dce --insecure llm-studio adminmodelmanagement get-model --model-id "$M" -o json | grep -o '"publicAccessModelName" *: *"[^"]*"' | cut -d'"' -f4)
 echo "### PUBLIC_NAME"; echo "$PUB"
 echo "### USAGE";   dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time "${S}T00:00:00Z" --end-time "${E}T00:00:00Z" --models "$PUB" --period TIME_PERIOD_DAY -o json | grep -A11 '"totalUsage"'
 echo "### SKU";     dce --insecure billing-center product list-sku-infos --page 1 --page-size 200 --product hydra-maas -o json | grep -E '"value"|"price"'
@@ -283,9 +283,10 @@ The `grep` filters keep the output small enough to fit the terminal window (raw 
 
 ```bash
 S="<start-date>"; E="<today-date>"
-echo "### MODELS"; dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json | grep '"modelId"'   # enumerate + self-hosted gate, grepped tiny; this replaces any separate list-models call
-for M in a-maas-deepseek-v4-pro a-maas-glm-5.1 a-maas-qwen3-32b a-maas-minimax-2.7; do
-  PUB=$(dce --insecure llm-studio adminmodelmanagement get-model --model-id "$M" -o json | grep -o '"publicAccessModelName" *: *"[^"]*"' | grep -o 'public/[^"]*')
+MODELS=$(dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" --page.page-size -1 -o json | grep -o '"modelId" *: *"[^"]*"' | cut -d'"' -f4 | grep -E '^a-maas-|^maas-')
+echo "### MODELS"; echo "$MODELS"   # enumerate + self-hosted gate, grepped tiny; this replaces any separate list-models call
+for M in $MODELS; do
+  PUB=$(dce --insecure llm-studio adminmodelmanagement get-model --model-id "$M" -o json | grep -o '"publicAccessModelName" *: *"[^"]*"' | cut -d'"' -f4)
   echo "### USAGE $M -> $PUB"
   dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time "${S}T00:00:00Z" --end-time "${E}T00:00:00Z" --models "$PUB" --period TIME_PERIOD_DAY -o json | grep -A11 '"totalUsage"'
 done

--- a/skills/ai-inference:llm-roi-analysis/SKILL.md
+++ b/skills/ai-inference:llm-roi-analysis/SKILL.md
@@ -151,9 +151,11 @@ GPUs and sets the per-token sale price (cost = GPU hourly price × pod-hours).
 **Resold upstream API is pass-through** (cost = upstream token price, no GPU to
 right-size) and is OUT OF SCOPE.
 
-Before any analysis, confirm self-hosting via the API-visible marker: the model
+Confirm self-hosting via the API-visible marker: the model
 appears in `list-models --page.search "modelId=maas-"` and its `modelId`
-**starts with** `maas-` **or** `a-maas-` (this deployment registers the
+**starts with** `maas-` **or** `a-maas-`. **Do this inside the single bundle
+command** (its first `### MODELS` line is a grepped `list-models`); do NOT run
+`list-models` as its own tool call. (This deployment registers the
 self-hosted models under the `a-maas-` variant — treat it as a `maas-` marker).
 (The `models` API does not expose `source` or `resources_requirements`, so the
 `maas-`/`a-maas-` prefix is the operative marker; `source=BUILTIN` + a running
@@ -250,23 +252,48 @@ Business window default `2026-06-01` → today. Before calling tools, resolve:
 - `<model>` = requested self-hosted MaaS model id, or every selected `maas-*`
   model for portfolio analysis.
 
-Step 0 — enumerate models once:
+**Do NOT run `list-models` (or any read) as a separate tool call.** Model
+enumeration + the self-hosted gate are the first `### MODELS` line **inside** the
+single bundle command below (a grepped `list-models` that returns just the
+`modelId`s). The entire analysis is **one** `dce`-bundle tool call, start to
+finish.
 
-`dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json` — keep only `modelId` values that start with `maas-`.
+Then run the whole data bundle for the model in **ONE shell command = one tool
+call** (this is the speed fix — do NOT issue 5–6 separate tool calls; that is
+what makes an analysis take minutes). Copy this block, set the 3 variables, and
+run it once; then parse the labelled `### SECTION` blocks from the single output:
 
-Then, for each selected model, perform **one model-bundle tool call**. The tool
-message must contain all reads below for that model; do not split them into
-separate tool messages:
-
-```text
-model bundle for <model>:
-  1. dce --insecure llm-studio modelservingmanagement list-model-serving -o json
-  2a. dce --insecure llm-studio adminmodelmanagement get-model --model-id <modelId> -o json   # read .publicAccessModelName (e.g. public/a-maas-deepseek-v4-pro)
-  2b. dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time <start>T00:00:00Z --end-time <today>T00:00:00Z --models <publicAccessModelName> --period TIME_PERIOD_DAY -o json   # use publicAccessModelName from 2a; bare modelId → empty/0
-  3. dce --insecure billing-center product list-sku-infos --page 1 --page-size 200 --product hydra-maas -o json
-  4. dce --insecure container-management core get-config-map --cluster kpanda-global-cluster --namespace tokenfactory-system --name tokenfactory-dashboard-resource-cost -o json
-  5. dce --insecure operations-management report list-pods --start <start> --end <today+1> --search <model> -o json
+```bash
+M="<modelId>"; S="<start-date>"; E="<today-date>"   # e.g. M=a-maas-deepseek-v4-pro S=2026-07-08 E=2026-07-15
+# publicAccessModelName is captured with grep (do NOT pipe to `python -c` — the harness blocks -c scripts)
+echo "### MODELS"; dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json | grep '"modelId"'   # enumerate + self-hosted gate, grepped tiny; replaces any separate list-models call
+PUB=$(dce --insecure llm-studio adminmodelmanagement get-model --model-id "$M" -o json | grep -o '"publicAccessModelName" *: *"[^"]*"' | grep -o 'public/[^"]*')
+echo "### PUBLIC_NAME"; echo "$PUB"
+echo "### USAGE";   dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time "${S}T00:00:00Z" --end-time "${E}T00:00:00Z" --models "$PUB" --period TIME_PERIOD_DAY -o json | grep -A11 '"totalUsage"'
+echo "### SKU";     dce --insecure billing-center product list-sku-infos --page 1 --page-size 200 --product hydra-maas -o json | grep -E '"value"|"price"'
+echo "### GPUCOST"; dce --insecure container-management core get-config-map --cluster kpanda-global-cluster --namespace tokenfactory-system --name tokenfactory-dashboard-resource-cost -o json
+echo "### UTIL";    dce --insecure operations-management report list-pods --start "$S" --end "$E" --search "$M" -o json | grep -E '"pod"|"avgGpuUseRatio"|"maxGpuUseRatio"'
 ```
+
+The `grep` filters keep the output small enough to fit the terminal window (raw JSON is truncated at ~5 KB and you would lose the later sections). `grep -A11 '"totalUsage"'` gives the window totals (revenue inputs); `"value"|"price"` gives each SKU's model-name + token-type + price; the util grep gives per-pod avg/max. If you also need the daily trend, re-run just the USAGE line without the grep for the one model in question.
+
+- `E` = today's date (`--end-time ${E}T00:00:00Z` is exclusive, so the usage window is complete days only per the Window-alignment rule).
+- Replicas come from the fixed mapping table above (4/4/3/2) — `list-model-serving` is optional and omitted here to save a round-trip; add `; echo "### SERVING"; dce --insecure llm-studio modelservingmanagement list-model-serving -o json` only if you must confirm replicas.
+- **Portfolio (multiple models): also ONE shell command = one tool call** — a `for` loop over the models, still a single terminal call (do NOT run each read as its own command, and do NOT use a comma-joined `--models`: with multiple models `totalUsage` becomes the SUM ACROSS ALL of them, corrupting per-model revenue). Each model gets its own clean `totalUsage`; SKU/GPUCOST/UTIL are model-independent → pulled once:
+
+```bash
+S="<start-date>"; E="<today-date>"
+echo "### MODELS"; dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json | grep '"modelId"'   # enumerate + self-hosted gate, grepped tiny; this replaces any separate list-models call
+for M in a-maas-deepseek-v4-pro a-maas-glm-5.1 a-maas-qwen3-32b a-maas-minimax-2.7; do
+  PUB=$(dce --insecure llm-studio adminmodelmanagement get-model --model-id "$M" -o json | grep -o '"publicAccessModelName" *: *"[^"]*"' | grep -o 'public/[^"]*')
+  echo "### USAGE $M -> $PUB"
+  dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time "${S}T00:00:00Z" --end-time "${E}T00:00:00Z" --models "$PUB" --period TIME_PERIOD_DAY -o json | grep -A11 '"totalUsage"'
+done
+echo "### SKU";     dce --insecure billing-center product list-sku-infos --page 1 --page-size 200 --product hydra-maas -o json | grep -E '"value"|"price"'
+echo "### GPUCOST"; dce --insecure container-management core get-config-map --cluster kpanda-global-cluster --namespace tokenfactory-system --name tokenfactory-dashboard-resource-cost -o json
+echo "### UTIL";    dce --insecure operations-management report list-pods --start "$S" --end "$E" --search a-maas -o json | grep -E '"pod"|"avgGpuUseRatio"|"maxGpuUseRatio"'
+```
+Each model's revenue = its own `### USAGE <M>` block's `totalUsage.input` and `totalUsage.output`. The `grep`s keep the whole output under the terminal's ~5 KB window (raw JSON overflows and truncates everything after the first section) — do NOT echo the full `list-models` here (it is huge and redundant; the loop already names the models). Never fan out to per-API or per-model separate tool calls.
 
 Interpretation:
 

--- a/skills/ai-inference:llm-roi-analysis/references/playbooks/llm-model-portfolio-roi-analysis.md
+++ b/skills/ai-inference:llm-roi-analysis/references/playbooks/llm-model-portfolio-roi-analysis.md
@@ -60,9 +60,10 @@ labelled `### SECTION` blocks:
 
 ```bash
 S="<start-date>"; E="<today-date>"   # E exclusive → usage window = complete days only
-echo "### MODELS"; dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json | grep '"modelId"'   # enumerate + gate, grepped; do NOT run list-models as a separate call
-for M in a-maas-deepseek-v4-pro a-maas-glm-5.1 a-maas-qwen3-32b a-maas-minimax-2.7; do
-  PUB=$(dce --insecure llm-studio adminmodelmanagement get-model --model-id "$M" -o json | grep -o '"publicAccessModelName" *: *"[^"]*"' | grep -o 'public/[^"]*')
+MODELS=$(dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" --page.page-size -1 -o json | grep -o '"modelId" *: *"[^"]*"' | cut -d'"' -f4 | grep -E '^a-maas-|^maas-')
+echo "### MODELS"; echo "$MODELS"   # enumerate + gate, grepped; do NOT run list-models as a separate call
+for M in $MODELS; do
+  PUB=$(dce --insecure llm-studio adminmodelmanagement get-model --model-id "$M" -o json | grep -o '"publicAccessModelName" *: *"[^"]*"' | cut -d'"' -f4)
   echo "### USAGE $M -> $PUB"
   dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time "${S}T00:00:00Z" --end-time "${E}T00:00:00Z" --models "$PUB" --period TIME_PERIOD_DAY -o json | grep -A11 '"totalUsage"'
 done

--- a/skills/ai-inference:llm-roi-analysis/references/playbooks/llm-model-portfolio-roi-analysis.md
+++ b/skills/ai-inference:llm-roi-analysis/references/playbooks/llm-model-portfolio-roi-analysis.md
@@ -48,24 +48,36 @@ call that runs the model bundle for that model. Every `dce` command must include
 `--insecure` immediately after `dce`. Do not split one model's work into
 usage-only, SKU-only, utilization-only, or retry narration tool messages.
 
-**Tool message shape for full-system portfolio analysis:**
+**Collect the whole portfolio in ONE shell command = one tool call** (speed fix —
+do NOT fan out to per-model or per-API tool calls). ⛔ **Query usage PER MODEL, one
+`--models` value at a time** — do NOT pass a comma-joined list. With a
+multi-model `--models`, `totalUsage` is the **SUM ACROSS ALL those models**, so
+using it for any single model's revenue is wrong (this is exactly what produces a
+model reported at −186% when it is actually profitable). A shell `for` loop keeps
+it to one command while giving each model its own clean `totalUsage`. SKU / GPU
+price / util are model-independent — pull once. Set the vars, run once, parse the
+labelled `### SECTION` blocks:
 
-```text
-tool call 0:
-  dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json
-  client-side: keep only modelId values that start with maas- or a-maas-
-
-tool call 1, model bundle for <model-1>:
-  1. dce --insecure llm-studio modelservingmanagement list-model-serving -o json
-  2a. dce --insecure llm-studio adminmodelmanagement get-model --model-id <modelId> -o json   # read .publicAccessModelName (the request name; do NOT hardcode the public/ prefix)
-  2b. dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time <start>T00:00:00Z --end-time <today>T00:00:00Z --models <publicAccessModelName> --period TIME_PERIOD_DAY -o json   # use publicAccessModelName from 2a; bare modelId → empty/0 (NOT zero demand). Do not drop --models (times out). If usage=0 but serving RUNNING + util>0, re-check the name from get-model.
-  3. dce --insecure billing-center product list-sku-infos --page 1 --page-size 200 --product hydra-maas -o json
-  4. dce --insecure container-management core get-config-map --cluster kpanda-global-cluster --namespace tokenfactory-system --name tokenfactory-dashboard-resource-cost -o json
-  5. dce --insecure operations-management report list-pods --start <start> --end <today+1> --search <model-1> -o json
-
-tool call 2, model bundle for <model-2>:
-  same five reads with <model-2> substituted
+```bash
+S="<start-date>"; E="<today-date>"   # E exclusive → usage window = complete days only
+echo "### MODELS"; dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json | grep '"modelId"'   # enumerate + gate, grepped; do NOT run list-models as a separate call
+for M in a-maas-deepseek-v4-pro a-maas-glm-5.1 a-maas-qwen3-32b a-maas-minimax-2.7; do
+  PUB=$(dce --insecure llm-studio adminmodelmanagement get-model --model-id "$M" -o json | grep -o '"publicAccessModelName" *: *"[^"]*"' | grep -o 'public/[^"]*')
+  echo "### USAGE $M -> $PUB"
+  dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time "${S}T00:00:00Z" --end-time "${E}T00:00:00Z" --models "$PUB" --period TIME_PERIOD_DAY -o json | grep -A11 '"totalUsage"'
+done
+echo "### SKU";     dce --insecure billing-center product list-sku-infos --page 1 --page-size 200 --product hydra-maas -o json | grep -E '"value"|"price"'
+echo "### GPUCOST"; dce --insecure container-management core get-config-map --cluster kpanda-global-cluster --namespace tokenfactory-system --name tokenfactory-dashboard-resource-cost -o json
+echo "### UTIL";    dce --insecure operations-management report list-pods --start "$S" --end "$E" --search a-maas -o json | grep -E '"pod"|"avgGpuUseRatio"|"maxGpuUseRatio"'
 ```
+The `grep`s keep the single command's output under the terminal's ~5 KB window (raw JSON overflows → everything after the first section is truncated and the agent re-queries). `grep -A11 '"totalUsage"'` per model = that model's window revenue inputs; do NOT echo the full `list-models` (huge + redundant). If you need the daily trend for one model, re-run just its USAGE line without the grep.
+
+Each model's revenue = **its own `### USAGE <M>` block's `totalUsage.input` and
+`totalUsage.output`** (price each and add). `publicAccessModelName` comes from
+`get-model` (do NOT hardcode `public/`; `grep`, not `python -c`). Replicas come
+from the fixed mapping (4/4/3/2); `list-model-serving` is optional. **Sanity per
+model:** nonzero GPU util ⟹ billions of tokens/week — if a model's `totalUsage`
+implies only tens of millions, you read the wrong model's block.
 
 Collect the complete result set first, then calculate and answer. Do not send
 separate tool messages like "pull tokens for every model", "pull SKU for every
@@ -89,7 +101,7 @@ Pinned command outputs used for portfolio rows:
 |---|---|
 | self-hosted model list | model-list read: model IDs starting with `maas-` |
 | replicas | model bundle read 1: serving `replicas`; client-side filter by model/serving name |
-| token volume + daily trend | model bundle read 2: **revenue = `totalUsage.input`/1e6 × input_¥/M + `totalUsage.output`/1e6 × output_¥/M** (`totalUsage.input` and `totalUsage.output` are two separate token counts — price each and ADD, this is NOT a division; with `--end-time <today>T00:00:00Z` `totalUsage` already covers complete days only and sums all days + all `modelType` rows — do NOT hand-sum `dataPoints`). `dataPoints` are for the daily trend only: values are per-day (NOT cumulative), and each day may have multiple `modelType` rows (`REQUEST_MODEL_TYPE_UNSPECIFIED` + `TEXT_GENERATION`) that you must **sum**, never pick one. Sanity: nonzero GPU util ⟹ billions of tokens/week, not tens of millions. |
+| token volume + daily trend | **per model, from that model's OWN `### USAGE <M>` block** (one `--models` value each — never a comma-joined call, whose `totalUsage` is the all-models sum): **revenue = `totalUsage.input`/1e6 × input_¥/M + `totalUsage.output`/1e6 × output_¥/M** (`totalUsage.input` and `totalUsage.output` are two separate token counts — price each and ADD, NOT a division; `--end-time <today>T00:00:00Z` makes `totalUsage` cover complete days only and sum all days + all `modelType` rows — do NOT hand-sum `dataPoints`). `dataPoints` are for the daily trend only: per-day (NOT cumulative), each day may carry multiple `modelType` rows (`REQUEST_MODEL_TYPE_UNSPECIFIED` + `TEXT_GENERATION`) — sum them. Sanity per model: nonzero GPU util ⟹ billions of tokens/week, not tens of millions. |
 | input/output sale price | model bundle read 3: hydra-maas SKU where `specFields.model-name` == model |
 | GPU hourly price | model bundle read 4: `resourceCostSettings.gpus[].price`, keyed by fixed GPU product mapping |
 | utilization | model bundle read 5: `data.avgGpuUseRatio`, `data.maxGpuUseRatio`, `data.minGpuUseRatio` |

--- a/skills/ai-inference:llm-roi-analysis/references/playbooks/llm-roi-cost-analysis.md
+++ b/skills/ai-inference:llm-roi-analysis/references/playbooks/llm-roi-cost-analysis.md
@@ -25,17 +25,22 @@ outputs. Every `dce` command in the bundle must include `--insecure`
 immediately after `dce`. Do not split the work into preflight, discovery,
 usage-only, SKU-only, utilization-only, or retry narration steps.
 
-**One tool message shape for single-model analysis:**
+**Collect everything in ONE shell command = one tool call** (speed fix — a
+single-model analysis must not take 5–6 separate tool calls). Set the vars, run
+once, parse the labelled `### SECTION` blocks:
 
-```text
-tool call 1, model bundle for <model>:
-  1. dce --insecure llm-studio modelservingmanagement list-model-serving -o json
-  2a. dce --insecure llm-studio adminmodelmanagement get-model --model-id <modelId> -o json   # read .publicAccessModelName (the request name; do NOT hardcode the public/ prefix)
-  2b. dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time <start>T00:00:00Z --end-time <today>T00:00:00Z --models <publicAccessModelName> --period TIME_PERIOD_DAY -o json   # use publicAccessModelName from 2a; bare modelId → empty/0 (NOT zero demand). Do not drop --models (times out). If usage=0 but serving RUNNING + util>0, re-check the name from get-model; never report "demand collapsed / 空转".
-  3. dce --insecure billing-center product list-sku-infos --page 1 --page-size 200 --product hydra-maas -o json
-  4. dce --insecure container-management core get-config-map --cluster kpanda-global-cluster --namespace tokenfactory-system --name tokenfactory-dashboard-resource-cost -o json
-  5. dce --insecure operations-management report list-pods --start <start> --end <today+1> --search <model> -o json
+```bash
+M="<modelId>"; S="<start-date>"; E="<today-date>"   # e.g. M=a-maas-deepseek-v4-pro S=2026-07-08 E=2026-07-15 ; E exclusive → complete days only
+echo "### MODELS"; dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json | grep '"modelId"'   # enumerate + gate, grepped; do NOT run list-models as a separate call
+PUB=$(dce --insecure llm-studio adminmodelmanagement get-model --model-id "$M" -o json | grep -o '"publicAccessModelName" *: *"[^"]*"' | grep -o 'public/[^"]*')   # capture the request name; do NOT hardcode public/ , do NOT pipe to python -c (blocked)
+echo "### PUBLIC_NAME"; echo "$PUB"
+echo "### USAGE";   dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time "${S}T00:00:00Z" --end-time "${E}T00:00:00Z" --models "$PUB" --period TIME_PERIOD_DAY -o json | grep -A11 '"totalUsage"'
+echo "### SKU";     dce --insecure billing-center product list-sku-infos --page 1 --page-size 200 --product hydra-maas -o json | grep -E '"value"|"price"'
+echo "### GPUCOST"; dce --insecure container-management core get-config-map --cluster kpanda-global-cluster --namespace tokenfactory-system --name tokenfactory-dashboard-resource-cost -o json
+echo "### UTIL";    dce --insecure operations-management report list-pods --start "$S" --end "$E" --search "$M" -o json | grep -E '"pod"|"avgGpuUseRatio"|"maxGpuUseRatio"'
 ```
+
+Replicas come from the fixed mapping (4/4/3/2); add `; echo "### SERVING"; dce --insecure llm-studio modelservingmanagement list-model-serving -o json` only if you must confirm them. `bare modelId → empty/0` (not zero demand); if usage=0 while serving RUNNING and util>0, re-check `$PUB`.
 
 - Keep the tool transcript compact: one model bundle, then calculation and
   answer. If the self-hosted model set is unknown, run only the model-list read

--- a/skills/ai-inference:llm-roi-analysis/references/playbooks/llm-roi-cost-analysis.md
+++ b/skills/ai-inference:llm-roi-analysis/references/playbooks/llm-roi-cost-analysis.md
@@ -32,7 +32,7 @@ once, parse the labelled `### SECTION` blocks:
 ```bash
 M="<modelId>"; S="<start-date>"; E="<today-date>"   # e.g. M=a-maas-deepseek-v4-pro S=2026-07-08 E=2026-07-15 ; E exclusive → complete days only
 echo "### MODELS"; dce --insecure llm-studio adminmodelmanagement list-models --page.search "modelId=maas-" -o json | grep '"modelId"'   # enumerate + gate, grepped; do NOT run list-models as a separate call
-PUB=$(dce --insecure llm-studio adminmodelmanagement get-model --model-id "$M" -o json | grep -o '"publicAccessModelName" *: *"[^"]*"' | grep -o 'public/[^"]*')   # capture the request name; do NOT hardcode public/ , do NOT pipe to python -c (blocked)
+PUB=$(dce --insecure llm-studio adminmodelmanagement get-model --model-id "$M" -o json | grep -o '"publicAccessModelName" *: *"[^"]*"' | cut -d'"' -f4)   # capture the complete request name; do NOT pipe to python -c (blocked)
 echo "### PUBLIC_NAME"; echo "$PUB"
 echo "### USAGE";   dce --insecure llm-studio apikeymanagement get-api-key-usage-statistics2 --start-time "${S}T00:00:00Z" --end-time "${E}T00:00:00Z" --models "$PUB" --period TIME_PERIOD_DAY -o json | grep -A11 '"totalUsage"'
 echo "### SKU";     dce --insecure billing-center product list-sku-infos --page 1 --page-size 200 --product hydra-maas -o json | grep -E '"value"|"price"'


### PR DESCRIPTION
## What

Follow-up to #47. Makes the `ai-inference:llm-roi-analysis` data collection **one shell command = one tool call**, and shrinks its output so it fits the terminal window. No new correctness logic — this is about how the agent pulls the data.

## Why

After #47 the numbers were correct, but a run still fanned out into many separate `dce` tool calls (minutes per analysis), and a single big bundle got **truncated** at the terminal's ~5 KB window (the full `list-models` with model descriptions ate the budget, so the agent couldn't see USAGE/SKU/UTIL and re-queried).

## Changes

- **One-shot bundle**: a grepped `list-models` (enumerate + self-hosted gate) is the **first line inside** the bundle; then a per-model loop (`get-model` → `publicAccessModelName` → usage). The Self-Hosted Gate / Step-0 text now says *do not* run `list-models` as a separate call.
- **Portfolio**: query usage **per model** (never a comma-joined `--models` — with multiple models `totalUsage` is the sum across all of them and corrupts per-model revenue).
- **Output shrink**: pipe `usage → grep -A11 totalUsage`, `SKU → "value"|"price"`, `util → pod+avg/max`, so the whole command fits the window (raw JSON overflowed → everything after the first section truncated).

Docs-only; no code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
